### PR TITLE
Remove readiness probe for an HTTP endpoint the service does not expose

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -55,12 +55,3 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.server.http.port }}
-        readinessProbe:
-          httpGet:
-            path: /isAlive
-            port: {{ .Values.server.http.port }}
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 2
-          failureThreshold: 2
-          timeoutSeconds: 5


### PR DESCRIPTION
The chart probes `GET /isAlive` on the http port, but `main.go` starts only the NATS goroutines (metadata publisher, credential request/reply) — there is no HTTP listener, so the probe can never succeed and the pod is permanently unready.

Practical consequences observed in a smartdeployment-provisioned OCM-W stack: rolling updates wedge (new pod never becomes ready at `maxUnavailable: 0`), and the old pod keeps broadcasting outdated issuer metadata over NATS while the replacement never takes over — readiness gates service endpoints, not NATS traffic.

This removes the probe so the deployment reflects how the service actually works. If an HTTP health endpoint is added to the service later, the probe can be reinstated with it.